### PR TITLE
enable using tuples instead of lists in ballot grouping mode

### DIFF
--- a/py3votecore/condorcet.py
+++ b/py3votecore/condorcet.py
@@ -30,13 +30,12 @@ class CondorcetHelper(object):
         self.ballots = ballots
         if ballot_notation == CondorcetHelper.BALLOT_NOTATION_GROUPING:
             for ballot in self.ballots:
-                ballot["ballot"].reverse()
                 new_ballot = {}
-                r = 0
+                r = len(ballot["ballot"])
                 for rank in ballot["ballot"]:
-                    r += 1
                     for candidate in rank:
                         new_ballot[candidate] = r
+                    r -= 1
                 ballot["ballot"] = new_ballot
         elif ballot_notation == CondorcetHelper.BALLOT_NOTATION_RANKING:
             for ballot in self.ballots:

--- a/test_functionality/test_schulze_method.py
+++ b/test_functionality/test_schulze_method.py
@@ -154,6 +154,22 @@ class TestSchulzeMethod(unittest.TestCase):
         })
         self.assertEqual(output['tied_winners'], set(['A', 'B']))
 
+    def test_tuple_ballots(self):
+
+        # Generate data
+        input_tuple = [
+            {"count": 1, "ballot": (("A"), ("B", "C"))},
+            {"count": 1, "ballot": (("B"), ("A"), ("C"))},
+        ]
+        input_list = [
+            {"count": 1, "ballot": [["A"], ["B", "C"]]},
+            {"count": 1, "ballot": [["B"], ["A"], ["C"]]},
+        ]
+        output_tuple = SchulzeMethod(input_tuple, ballot_notation=SchulzeMethod.BALLOT_NOTATION_GROUPING).as_dict()
+        output_list = SchulzeMethod(input_list, ballot_notation=SchulzeMethod.BALLOT_NOTATION_GROUPING).as_dict()
+
+        # Run tests
+        self.assertEqual(output_tuple, output_list)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This enables using tuples instead of lists as ballots in ballot grouping mode, all tests still pass